### PR TITLE
feat(products-service): implement PUT /products/{id} with optimistic locking

### DIFF
--- a/contracts/products/products-v1.yaml
+++ b/contracts/products/products-v1.yaml
@@ -115,6 +115,38 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+    put:
+      tags: [ Products ]
+      summary: Update a product by id (optimistic locking)
+      operationId: updateProductById
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProductRequest'
+      responses:
+        '200':
+          description: Product updated successfully
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/Product' }
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Conflict (version mismatch or SKU already exists)
+          content:
+            application/json:
+              schema:
+                $ref: '../common/components.yaml#/components/schemas/Problem'
+
 
 components:
   schemas:
@@ -220,3 +252,14 @@ components:
           type: boolean
           default: false
       additionalProperties: false
+
+    UpdateProductRequest:
+      type: object
+      required: [ sku, name, price, stock, category, version ]
+      properties:
+        sku: { type: string, minLength: 1, example: "ACME-123" }
+        name: { type: string, minLength: 1, example: "Laptop Pro 14" }
+        price: { type: number, format: double, minimum: 0, example: 1199.99 }
+        stock: { type: integer, minimum: 0, example: 12 }
+        category: { type: string, minLength: 1, example: "laptops" }
+        version: { type: integer, minimum: 0, example: 3 }

--- a/products-service/src/main/java/com/jorgeandreu/products/application/exception/ProductVersionConflictException.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/application/exception/ProductVersionConflictException.java
@@ -1,0 +1,7 @@
+package com.jorgeandreu.products.application.exception;
+
+public class ProductVersionConflictException extends RuntimeException {
+    public ProductVersionConflictException(java.util.UUID id, long version) {
+        super("Version conflict updating product %s with expected version %d".formatted(id, version));
+    }
+}

--- a/products-service/src/main/java/com/jorgeandreu/products/application/service/ProductUpdateService.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/application/service/ProductUpdateService.java
@@ -1,0 +1,50 @@
+package com.jorgeandreu.products.application.service;
+
+
+import com.jorgeandreu.products.application.exception.ProductNotFoundException;
+import com.jorgeandreu.products.application.exception.ProductVersionConflictException;
+import com.jorgeandreu.products.application.exception.SkuAlreadyExistsException;
+import com.jorgeandreu.products.domain.port.in.UpdateProductCommand;
+import com.jorgeandreu.products.domain.port.in.UpdateProductUseCase;
+import com.jorgeandreu.products.domain.port.out.ProductRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProductUpdateService implements UpdateProductUseCase {
+
+    private final ProductRepositoryPort repository;
+
+    @Override
+    @Transactional
+    public void updateById(UUID id, UpdateProductCommand cmd) {
+        try {
+            int updated = repository.updateIfVersionMatches(
+                    id,
+                    cmd.sku(),
+                    cmd.name(),
+                    cmd.price(),
+                    cmd.stock(),
+                    cmd.category(),
+                    cmd.version(),
+                    Instant.now()
+            );
+
+            if (updated == 1) return;
+
+            boolean existsActive = repository.existsActiveById(id);
+            if (existsActive) {
+                throw new ProductVersionConflictException(id, cmd.version());
+            } else {
+                throw new ProductNotFoundException(id);
+            }
+        } catch (org.springframework.dao.DataIntegrityViolationException ex) {
+            throw new SkuAlreadyExistsException(cmd.sku());
+        }
+    }
+}

--- a/products-service/src/main/java/com/jorgeandreu/products/domain/port/in/UpdateProductCommand.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/domain/port/in/UpdateProductCommand.java
@@ -1,0 +1,17 @@
+package com.jorgeandreu.products.domain.port.in;
+
+import java.math.BigDecimal;
+
+public record UpdateProductCommand(
+        String sku,
+        String name,
+        BigDecimal price,
+        Integer stock,
+        String category,
+        long version
+) {
+    public UpdateProductCommand {
+        if (price == null || price.signum() < 0) throw new IllegalArgumentException("price must be >= 0");
+        if (stock == null || stock < 0) throw new IllegalArgumentException("stock must be >= 0");
+    }
+}

--- a/products-service/src/main/java/com/jorgeandreu/products/domain/port/in/UpdateProductUseCase.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/domain/port/in/UpdateProductUseCase.java
@@ -1,0 +1,7 @@
+package com.jorgeandreu.products.domain.port.in;
+
+import java.util.UUID;
+
+public interface UpdateProductUseCase {
+    void updateById(UUID id, UpdateProductCommand command);
+}

--- a/products-service/src/main/java/com/jorgeandreu/products/domain/port/out/ProductRepositoryPort.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/domain/port/out/ProductRepositoryPort.java
@@ -4,6 +4,7 @@ import com.jorgeandreu.products.domain.model.PageResult;
 import com.jorgeandreu.products.domain.model.Product;
 import com.jorgeandreu.products.domain.model.SearchCriteria;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,4 +15,15 @@ public interface ProductRepositoryPort {
     Optional<Product> findById(UUID id);
     PageResult<Product> search(SearchCriteria criteria);
     boolean softDeleteById(UUID id, Instant deletedAt);
+    int updateIfVersionMatches(UUID id,
+                               String sku,
+                               String name,
+                               BigDecimal price,
+                               Integer stock,
+                               String category,
+                               long expectedVersion,
+                               Instant updatedAt);
+
+    /** @return true if product exists and is not soft-deleted */
+    boolean existsActiveById(UUID id);
 }

--- a/products-service/src/main/java/com/jorgeandreu/products/infrastructure/db/ProductRepositoryAdapter.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/infrastructure/db/ProductRepositoryAdapter.java
@@ -5,6 +5,7 @@ import com.jorgeandreu.products.domain.model.Product;
 import com.jorgeandreu.products.domain.model.SearchCriteria;
 import com.jorgeandreu.products.domain.port.out.ProductRepositoryPort;
 import com.jorgeandreu.products.infrastructure.db.mapper.ProductEntityMapper;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
@@ -72,6 +74,16 @@ public class ProductRepositoryAdapter implements ProductRepositoryPort {
     public boolean softDeleteById(UUID id, Instant deletedAt) {
         int updated = repository.softDeleteIfNotDeleted(id, deletedAt);
         return updated == 1;
+    }
+
+    @Override
+    public int updateIfVersionMatches(UUID id, String sku, String name, BigDecimal price, Integer stock, String category, long expectedVersion, Instant updatedAt) throws DataIntegrityViolationException {
+        return repository.updateIfVersionMatches(id, sku, name, price, stock, category, expectedVersion, updatedAt);
+    }
+
+    @Override
+    public boolean existsActiveById(UUID id) {
+        return repository.existsByIdAndDeletedAtIsNull(id);
     }
 
     // --- Specifications (static helpers) ---

--- a/products-service/src/main/java/com/jorgeandreu/products/infrastructure/web/GlobalExceptionHandler.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/infrastructure/web/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.jorgeandreu.products.infrastructure.web;
+
 import com.jorgeandreu.products.application.exception.ProductNotFoundException;
+import com.jorgeandreu.products.application.exception.ProductVersionConflictException;
 import com.jorgeandreu.products.application.exception.SkuAlreadyExistsException;
 import com.jorgeandreu.products.infrastructure.api.model.Problem;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 
 import java.net.URI;
@@ -74,6 +76,17 @@ public class GlobalExceptionHandler {
                 .type(URI.create(URI.create("https://example.com/problems/internal-error").toString()))
                 .instance(path(req));
         return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(p);
+    }
+
+    @ExceptionHandler(ProductVersionConflictException.class)
+    public ResponseEntity<Problem> handleVersionConflict(ProductVersionConflictException ex, WebRequest req) {
+        var p = new Problem()
+                .title("Version conflict")
+                .status(CONFLICT.value())
+                .detail(ex.getMessage()) // e.g. "Version conflict updating product <id> with expected version <n>"
+                .type(URI.create(URI.create("https://example.com/problems/version-conflict").toString()))
+                .instance(path(req));
+        return ResponseEntity.status(CONFLICT).body(p);
     }
 
     private URI path(WebRequest req) {

--- a/products-service/src/main/java/com/jorgeandreu/products/infrastructure/web/ProductWebMapper.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/infrastructure/web/ProductWebMapper.java
@@ -3,10 +3,12 @@ package com.jorgeandreu.products.infrastructure.web;
 import com.jorgeandreu.products.domain.model.PageResult;
 import com.jorgeandreu.products.domain.port.in.CreateProductCommand;
 import com.jorgeandreu.products.domain.port.in.SearchCriteriaCommand;
+import com.jorgeandreu.products.domain.port.in.UpdateProductCommand;
 import com.jorgeandreu.products.infrastructure.api.model.CreateProductRequest;
 import com.jorgeandreu.products.infrastructure.api.model.Product;
 import com.jorgeandreu.products.infrastructure.api.model.ProductPage;
 import com.jorgeandreu.products.infrastructure.api.model.ProductSearchCriteriaRequest;
+import com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -30,5 +32,7 @@ public interface ProductWebMapper {
 
     @Mapping(target = "content", qualifiedByName = "toApi")
     ProductPage toApi(PageResult<com.jorgeandreu.products.domain.model.Product> pageResult);
+
+    UpdateProductCommand toCommand(UpdateProductRequest req);
 
 }

--- a/products-service/src/main/java/com/jorgeandreu/products/infrastructure/web/ProductsApiDelegateImpl.java
+++ b/products-service/src/main/java/com/jorgeandreu/products/infrastructure/web/ProductsApiDelegateImpl.java
@@ -6,10 +6,12 @@ import com.jorgeandreu.products.domain.port.in.CreateProductUseCase;
 import com.jorgeandreu.products.domain.port.in.DeleteProductUseCase;
 import com.jorgeandreu.products.domain.port.in.GetProductUseCase;
 import com.jorgeandreu.products.domain.port.in.ListProductsUseCase;
+import com.jorgeandreu.products.domain.port.in.UpdateProductUseCase;
 import com.jorgeandreu.products.infrastructure.api.ProductsApiDelegate;
 import com.jorgeandreu.products.infrastructure.api.model.CreateProductRequest;
 import com.jorgeandreu.products.infrastructure.api.model.ProductPage;
 import com.jorgeandreu.products.infrastructure.api.model.ProductSearchCriteriaRequest;
+import com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -32,6 +34,8 @@ public class ProductsApiDelegateImpl implements ProductsApiDelegate {
     private final ListProductsUseCase listProductUC;
 
     private final DeleteProductUseCase deleteProductUC;
+
+    private final UpdateProductUseCase updateProductUC;
 
     @Override
     public ResponseEntity<com.jorgeandreu.products.infrastructure.api.model.Product> createProduct(CreateProductRequest req) {
@@ -61,5 +65,13 @@ public class ProductsApiDelegateImpl implements ProductsApiDelegate {
     public ResponseEntity<Void> deleteProductById(UUID id) {
         deleteProductUC.deleteById(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @Override
+    public ResponseEntity<com.jorgeandreu.products.infrastructure.api.model.Product> updateProductById(UUID id, UpdateProductRequest req) {
+        var cmd = webMapper.toCommand(req);
+        updateProductUC.updateById(id, cmd);
+        Product product = getProduct.getById(id);
+        return ResponseEntity.ok(webMapper.toApi(product));
     }
 }

--- a/products-service/src/test/java/com/jorgeandreu/products/application/service/ProductUpdateServiceTest.java
+++ b/products-service/src/test/java/com/jorgeandreu/products/application/service/ProductUpdateServiceTest.java
@@ -1,0 +1,102 @@
+package com.jorgeandreu.products.application.service;
+
+import com.jorgeandreu.products.application.exception.ProductNotFoundException;
+import com.jorgeandreu.products.application.exception.ProductVersionConflictException;
+import com.jorgeandreu.products.application.exception.SkuAlreadyExistsException;
+import com.jorgeandreu.products.domain.port.in.UpdateProductCommand;
+import com.jorgeandreu.products.domain.port.out.ProductRepositoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductUpdateServiceTest {
+
+    @Mock
+    private ProductRepositoryPort repository;
+
+    @InjectMocks
+    private ProductUpdateService service;
+
+    private static UpdateProductCommand cmd() {
+        return new UpdateProductCommand("ACME-1", "Name", BigDecimal.valueOf(10.0), 5, "laptops", 2);
+    }
+
+    @Nested
+    @DisplayName("updateById")
+    class UpdateById {
+
+        @Test
+        @DisplayName("updates when version matches (1 row affected)")
+        void success() {
+            UUID id = UUID.randomUUID();
+            given(repository.updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class)))
+                    .willReturn(1);
+
+            service.updateById(id, cmd());
+
+            then(repository).should().updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class));
+            then(repository).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("throws ProductVersionConflictException when 0 rows updated but product exists active")
+        void versionConflict() {
+            UUID id = UUID.randomUUID();
+            given(repository.updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class)))
+                    .willReturn(0);
+            given(repository.existsActiveById(id)).willReturn(true);
+
+            assertThatThrownBy(() -> service.updateById(id, cmd()))
+                    .isInstanceOf(ProductVersionConflictException.class);
+
+            then(repository).should().updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class));
+            then(repository).should().existsActiveById(id);
+            then(repository).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("throws ProductNotFoundException when 0 rows updated and product does not exist (or deleted)")
+        void notFound() {
+            UUID id = UUID.randomUUID();
+            given(repository.updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class)))
+                    .willReturn(0);
+            given(repository.existsActiveById(id)).willReturn(false);
+
+            assertThatThrownBy(() -> service.updateById(id, cmd()))
+                    .isInstanceOf(ProductNotFoundException.class);
+
+            then(repository).should().updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class));
+            then(repository).should().existsActiveById(id);
+            then(repository).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("translates DataIntegrityViolationException to SkuAlreadyExistsException (409)")
+        void skuConflict() {
+            UUID id = UUID.randomUUID();
+            given(repository.updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class)))
+                    .willThrow(new DataIntegrityViolationException("unique sku"));
+
+            assertThatThrownBy(() -> service.updateById(id, cmd()))
+                    .isInstanceOf(SkuAlreadyExistsException.class);
+
+            then(repository).should().updateIfVersionMatches(eq(id), anyString(), anyString(), any(), anyInt(), anyString(), anyLong(), any(Instant.class));
+            then(repository).shouldHaveNoMoreInteractions();
+        }
+    }
+}
+

--- a/products-service/src/test/java/com/jorgeandreu/products/infrastructure/web/GlobalExceptionHandlerTest.java
+++ b/products-service/src/test/java/com/jorgeandreu/products/infrastructure/web/GlobalExceptionHandlerTest.java
@@ -147,4 +147,30 @@ class GlobalExceptionHandlerTest {
             assertThat(p.getInstance()).isEqualTo(URI.create("/api/v1/products"));
         }
     }
+
+    @Nested
+    @DisplayName("Version conflict")
+    class VersionConflict {
+
+        @Test
+        void handleVersionConflict_returns409_withProblemPayload() {
+            UUID id = UUID.randomUUID();
+            var ex = new com.jorgeandreu.products.application.exception.ProductVersionConflictException(id, 3);
+
+            var response = handler.handleVersionConflict(ex, webRequest);
+
+            assertThat(response.getStatusCode().value()).isEqualTo(409);
+            Problem p = response.getBody();
+            assertThat(p).isNotNull();
+            assertThat(p.getTitle()).isEqualTo("Version conflict");
+            assertThat(p.getStatus()).isEqualTo(409);
+            // The exception message includes id and expected version
+            assertThat(p.getDetail())
+                    .contains(id.toString())
+                    .contains("3");
+            assertThat(p.getType()).isEqualTo(URI.create("https://example.com/problems/version-conflict"));
+            assertThat(p.getInstance()).isEqualTo(URI.create("/api/v1/products"));
+        }
+    }
+
 }

--- a/products-service/src/test/java/com/jorgeandreu/products/infrastructure/web/ProductWebMapperTest.java
+++ b/products-service/src/test/java/com/jorgeandreu/products/infrastructure/web/ProductWebMapperTest.java
@@ -103,7 +103,7 @@ class ProductWebMapperTest {
 
         @Test @DisplayName("returns null when request is null")
         void nullRequest() {
-            CreateProductCommand cmd = mapper.toCommand(null);
+            CreateProductCommand cmd = mapper.toCommand((CreateProductRequest) null);
             assertThat(cmd).isNull();
         }
 
@@ -260,4 +260,98 @@ class ProductWebMapperTest {
             assertThat(api.getContent().get(1)).isNull();
         }
     }
+
+    @Nested
+    @DisplayName("toCommand(UpdateProductRequest)")
+    class ToCommandUpdateRequest {
+
+        @Test
+        @DisplayName("maps all fields (double → BigDecimal, version preserved)")
+        void mapsAllFields() {
+            var req = new com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest()
+                    .sku("ACME-123")
+                    .name("Gaming Laptop")
+                    .price(1499.99)
+                    .stock(7)
+                    .category("laptops")
+                    .version(3);
+
+            var cmd = mapper.toCommand(req);
+
+            assertThat(cmd).isNotNull();
+            assertThat(cmd.sku()).isEqualTo("ACME-123");
+            assertThat(cmd.name()).isEqualTo("Gaming Laptop");
+            assertThat(cmd.price()).isEqualByComparingTo(BigDecimal.valueOf(1499.99));
+            assertThat(cmd.stock()).isEqualTo(7);
+            assertThat(cmd.category()).isEqualTo("laptops");
+            assertThat(cmd.version()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("null version → defaults to 0 (price provided)")
+        void nullVersionDefaultsToZero() {
+            var req = new com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest()
+                    .sku("ACME-456")
+                    .name("Ultrabook")
+                    .price(999.0)
+                    .stock(5)
+                    .category("laptops");
+
+            var cmd = mapper.toCommand(req);
+
+            assertThat(cmd).isNotNull();
+            assertThat(cmd.version()).isZero();
+            assertThat(cmd.price()).isEqualByComparingTo(BigDecimal.valueOf(999.0));
+            assertThat(cmd.stock()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("throws when price is null")
+        void throwsWhenPriceIsNull() {
+            var req = new com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest()
+                    .sku("ACME-789")
+                    .name("Pro")
+                    .stock(1)
+                    .category("laptops")
+                    .version(1);
+
+            org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> mapper.toCommand(req));
+        }
+
+        @Test
+        @DisplayName("throws when price is negative")
+        void throwsWhenPriceIsNegative() {
+            var req = new com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest()
+                    .sku("ACME-000")
+                    .name("Bad")
+                    .price(-1.0)
+                    .stock(1)
+                    .category("laptops")
+                    .version(1);
+
+            org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> mapper.toCommand(req));
+        }
+
+        @Test
+        @DisplayName("throws when stock is negative")
+        void throwsWhenStockIsNegative() {
+            var req = new com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest()
+                    .sku("ACME-001")
+                    .name("Bad Stock")
+                    .price(10.0)
+                    .stock(-5)
+                    .category("laptops")
+                    .version(1);
+
+            org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> mapper.toCommand(req));
+        }
+
+        @Test
+        @DisplayName("returns null when request is null")
+        void returnsNullWhenRequestIsNull() {
+            var cmd = mapper.toCommand((com.jorgeandreu.products.infrastructure.api.model.UpdateProductRequest) null);
+            assertThat(cmd).isNull();
+        }
+    }
+
 }


### PR DESCRIPTION
- Added OpenAPI contract for PUT /products/{id}.
- Implemented ProductUpdateService with UpdateProductUseCase.
- Added UpdateProductCommand record with validation (price >= 0, stock >= 0).
- Extended ProductRepositoryPort with updateIfVersionMatches and existsActiveById.
- Updated ProductRepositoryAdapter to delegate update and existence checks.
- Implemented updateProductById in ProductsApiDelegateImpl.
- Added GlobalExceptionHandler mapping for ProductVersionConflictException → 409.
- Comprehensive unit tests:
  - ProductsApiControllerStandaloneTest (PUT happy path, 400 invalid UUID, 404 not found, 409 conflict).
  - ProductsApiDelegateImplTest (updateProductById happy path + version conflict).
  - ProductUpdateServiceTest (success, version conflict, not found, SKU conflict).
  - ProductRepositoryAdapterTest (updateIfVersionMatches delegation, DataIntegrityViolation, existsActiveById).
  - GlobalExceptionHandlerTest (version conflict mapping).
  - ProductWebMapperTest (toCommand(UpdateProductRequest): happy path, null version, validation errors).